### PR TITLE
Drop sdp_answer messages that do not include SSRC attributes

### DIFF
--- a/lib/membrane_webrtc_plugin/endpoint_bin.ex
+++ b/lib/membrane_webrtc_plugin/endpoint_bin.ex
@@ -292,8 +292,12 @@ defmodule Membrane.WebRTC.EndpointBin do
       end)
       |> Enum.into(%{})
 
-    actions = set_remote_credentials(sdp)
-    {{:ok, actions}, Map.put(state, :ssrc_to_mid, ssrc_to_mid)}
+    if ssrc_to_mid == %{} do
+      {:ok, state}
+    else
+      actions = set_remote_credentials(sdp)
+      {{:ok, actions}, Map.put(state, :ssrc_to_mid, ssrc_to_mid)}
+    end
   end
 
   @impl true


### PR DESCRIPTION
Fixes #21 . 

This circumvents the case which causes `handle_notification({:new_rtp_stream, ssrc, pt}, _from, _ctx, state)` to crash.

I have not determined why in some cases Chrome creates answers with no `ssrc`, so I'm unsure if there are bad consequences of this change. 

If you have an alternative fix for this, I'm happy to close this pull request and implement your suggestions.