### PR TITLE
Set FIR interval to default (1s)

### DIFF
--- a/lib/membrane_webrtc_plugin/endpoint_bin.ex
+++ b/lib/membrane_webrtc_plugin/endpoint_bin.ex
@@ -440,8 +440,7 @@ defmodule Membrane.WebRTC.EndpointBin do
       extensions: ctx.options.extensions,
       rtp_extensions: rtp_extensions,
       clock_rate: rtp_mapping.clock_rate,
-      depayloader: depayloader,
-      rtcp_fir_interval: Membrane.Time.seconds(10)
+      depayloader: depayloader
     ]
 
     spec = %ParentSpec{


### PR DESCRIPTION
After fixing order in simulcast encoding array we can go back to default FIR interval which is eqaul to 1s. 