### PR TITLE
Update `SimpleWebSocketServer.handle_info` to accept `metadata`

### DIFF
--- a/lib/membrane_webrtc/simple_websocket_server.ex
+++ b/lib/membrane_webrtc/simple_websocket_server.ex
@@ -112,7 +112,7 @@ defmodule Membrane.WebRTC.SimpleWebSocketServer do
     end
 
     @impl true
-    def handle_info({SignalingChannel, _pid, message}, state) do
+    def handle_info({SignalingChannel, _pid, message, _metadata}, state) do
       {:push, {:text, Jason.encode!(message)}, state}
     end
 


### PR DESCRIPTION
The `send` in SignalingChannel also sends `metadata` now after the change in https://github.com/membraneframework/membrane_webrtc_plugin/commit/09bba0399b65912a959eea2790e0fbe0cc4f95fd