### PR TITLE
Add ex_webrtc options to Source and Sink

### DIFF
--- a/lib/membrane_webrtc/ex_webrtc/sink.ex
+++ b/lib/membrane_webrtc/ex_webrtc/sink.ex
@@ -16,7 +16,7 @@ defmodule Membrane.WebRTC.ExWebRTCSink do
 
   alias Membrane.WebRTC.{ExWebRTCUtils, Signaling, SimpleWebSocketServer}
 
-  def_options signaling: [], tracks: [], video_codec: [], ice_servers: []
+  def_options signaling: [], tracks: [], video_codec: [], ice_servers: [], ice_port_range: [], ice_ip_filter: fn _ -> true end
 
   def_input_pad :input,
     accepted_format: Membrane.RTP,
@@ -41,7 +41,9 @@ defmodule Membrane.WebRTC.ExWebRTCSink do
        audio_params: ExWebRTCUtils.codec_params(:opus),
        video_params: ExWebRTCUtils.codec_params(opts.video_codec),
        video_codec: opts.video_codec,
-       ice_servers: opts.ice_servers
+       ice_servers: opts.ice_servers,
+       ice_port_range: opts.ice_port_range,
+       ice_ip_filter: opts.ice_ip_filter
      }}
   end
 
@@ -69,6 +71,8 @@ defmodule Membrane.WebRTC.ExWebRTCSink do
     {:ok, pc} =
       PeerConnection.start_link(
         ice_servers: state.ice_servers,
+        ice_port_range: state.ice_port_range,
+        ice_ip_filter: state.ice_ip_filter,
         video_codecs: state.video_params,
         audio_codecs: state.audio_params
       )

--- a/lib/membrane_webrtc/ex_webrtc/sink.ex
+++ b/lib/membrane_webrtc/ex_webrtc/sink.ex
@@ -16,7 +16,7 @@ defmodule Membrane.WebRTC.ExWebRTCSink do
 
   alias Membrane.WebRTC.{ExWebRTCUtils, Signaling, SimpleWebSocketServer}
 
-  def_options signaling: [], tracks: [], video_codec: [], ice_servers: [], ice_port_range: [], ice_ip_filter: fn _ -> true end
+  def_options signaling: [], tracks: [], video_codec: [], ice_servers: [], ice_port_range: [], ice_ip_filter: []
 
   def_input_pad :input,
     accepted_format: Membrane.RTP,

--- a/lib/membrane_webrtc/ex_webrtc/source.ex
+++ b/lib/membrane_webrtc/ex_webrtc/source.ex
@@ -46,7 +46,7 @@ defmodule Membrane.WebRTC.ExWebRTCSource do
             preferred_video_codec: :h264 | :vp8,
             ice_servers: [ExWebRTC.PeerConnection.Configuration.ice_server()],
             ice_port_range: Enumerable.t(non_neg_integer()),
-            ice_ip_filter: (:inet.ip_address() -> boolean()) | nil,
+            ice_ip_filter: (:inet.ip_address() -> boolean()),
             keyframe_interval: Membrane.Time.t() | nil,
             sdp_candidates_timeout: Membrane.Time.t() | nil
           }

--- a/lib/membrane_webrtc/ex_webrtc/source.ex
+++ b/lib/membrane_webrtc/ex_webrtc/source.ex
@@ -13,7 +13,7 @@ defmodule Membrane.WebRTC.ExWebRTCSource do
               preferred_video_codec: [],
               ice_servers: [],
               ice_port_range: [],
-              ice_ip_filter: fn _ -> true end,
+              ice_ip_filter: [],
               keyframe_interval: [],
               sdp_candidates_timeout: []
 

--- a/lib/membrane_webrtc/ex_webrtc/source.ex
+++ b/lib/membrane_webrtc/ex_webrtc/source.ex
@@ -12,6 +12,8 @@ defmodule Membrane.WebRTC.ExWebRTCSource do
               allowed_video_codecs: [],
               preferred_video_codec: [],
               ice_servers: [],
+              ice_port_range: [],
+              ice_ip_filter: fn _ -> true end,
               keyframe_interval: [],
               sdp_candidates_timeout: []
 
@@ -43,6 +45,8 @@ defmodule Membrane.WebRTC.ExWebRTCSource do
             allowed_video_codecs: [:h264 | :vp8],
             preferred_video_codec: :h264 | :vp8,
             ice_servers: [ExWebRTC.PeerConnection.Configuration.ice_server()],
+            ice_port_range: Enumerable.t(non_neg_integer()),
+            ice_ip_filter: (:inet.ip_address() -> boolean()) | nil,
             keyframe_interval: Membrane.Time.t() | nil,
             sdp_candidates_timeout: Membrane.Time.t() | nil
           }
@@ -53,6 +57,8 @@ defmodule Membrane.WebRTC.ExWebRTCSource do
       :allowed_video_codecs,
       :preferred_video_codec,
       :ice_servers,
+      :ice_port_range,
+      :ice_ip_filter,
       :keyframe_interval,
       :sdp_candidates_timeout
     ]
@@ -78,6 +84,8 @@ defmodule Membrane.WebRTC.ExWebRTCSource do
        allowed_video_codecs: opts.allowed_video_codecs |> Enum.uniq(),
        preferred_video_codec: opts.preferred_video_codec,
        ice_servers: opts.ice_servers,
+       ice_port_range: opts.ice_port_range,
+       ice_ip_filter: opts.ice_ip_filter,
        keyframe_interval: opts.keyframe_interval,
        sdp_candidates_timeout: opts.sdp_candidates_timeout
      }}
@@ -321,6 +329,8 @@ defmodule Membrane.WebRTC.ExWebRTCSource do
     {:ok, pc} =
       PeerConnection.start(
         ice_servers: state.ice_servers,
+        ice_port_range: state.ice_port_range,
+        ice_ip_filter: state.ice_ip_filter,
         video_codecs: video_params,
         audio_codecs: state.audio_params
       )

--- a/lib/membrane_webrtc/sink.ex
+++ b/lib/membrane_webrtc/sink.ex
@@ -85,6 +85,14 @@ defmodule Membrane.WebRTC.Sink do
                 spec: [ExWebRTC.PeerConnection.Configuration.ice_server()],
                 default: [%{urls: "stun:stun.l.google.com:19302"}]
               ],
+              ice_port_range: [
+                spec: Enumerable.t(non_neg_integer()),
+                default: [0]
+              ],
+              ice_ip_filter: [
+                spec: (:inet.ip_address() -> boolean()) | nil,
+                default: fn _ -> true end
+              ],
               payload_rtp: [
                 spec: boolean(),
                 default: true
@@ -120,7 +128,9 @@ defmodule Membrane.WebRTC.Sink do
         signaling: opts.signaling,
         tracks: opts.tracks,
         video_codec: opts.video_codec,
-        ice_servers: opts.ice_servers
+        ice_servers: opts.ice_servers,
+        ice_port_range: opts.ice_port_range,
+        ice_ip_filter: opts.ice_ip_filter
       })
 
     {[spec: spec], %{payload_rtp: opts.payload_rtp, video_codec: opts.video_codec}}

--- a/lib/membrane_webrtc/sink.ex
+++ b/lib/membrane_webrtc/sink.ex
@@ -230,5 +230,5 @@ defmodule Membrane.WebRTC.Sink do
     {[], state}
   end
 
-  def default_ice_ip_filter(_), do: true
+  def default_ice_ip_filter(_ip), do: true
 end

--- a/lib/membrane_webrtc/sink.ex
+++ b/lib/membrane_webrtc/sink.ex
@@ -91,7 +91,7 @@ defmodule Membrane.WebRTC.Sink do
               ],
               ice_ip_filter: [
                 spec: (:inet.ip_address() -> boolean()) | nil,
-                default: fn _ -> true end
+                default: &__MODULE__.default_ice_ip_filter/1
               ],
               payload_rtp: [
                 spec: boolean(),
@@ -229,4 +229,6 @@ defmodule Membrane.WebRTC.Sink do
   def handle_element_end_of_stream(_name, _pad, _ctx, state) do
     {[], state}
   end
+
+  def default_ice_ip_filter(_), do: true
 end

--- a/lib/membrane_webrtc/sink.ex
+++ b/lib/membrane_webrtc/sink.ex
@@ -90,7 +90,7 @@ defmodule Membrane.WebRTC.Sink do
                 default: [0]
               ],
               ice_ip_filter: [
-                spec: (:inet.ip_address() -> boolean()) | nil,
+                spec: (:inet.ip_address() -> boolean()),
                 default: &__MODULE__.default_ice_ip_filter/1
               ],
               payload_rtp: [

--- a/lib/membrane_webrtc/source.ex
+++ b/lib/membrane_webrtc/source.ex
@@ -113,7 +113,7 @@ defmodule Membrane.WebRTC.Source do
                 default: [0]
               ],
               ice_ip_filter: [
-                spec: (:inet.ip_address() -> boolean()) | nil,
+                spec: (:inet.ip_address() -> boolean()),
                 default: &__MODULE__.default_ice_ip_filter/1
               ],
               depayload_rtp: [

--- a/lib/membrane_webrtc/source.ex
+++ b/lib/membrane_webrtc/source.ex
@@ -108,6 +108,14 @@ defmodule Membrane.WebRTC.Source do
                 spec: [ExWebRTC.PeerConnection.Configuration.ice_server()],
                 default: [%{urls: "stun:stun.l.google.com:19302"}]
               ],
+              ice_port_range: [
+                spec: Enumerable.t(non_neg_integer()),
+                default: [0]
+              ],
+              ice_ip_filter: [
+                spec: (:inet.ip_address() -> boolean()) | nil,
+                default: fn _ -> true end
+              ],
               depayload_rtp: [
                 spec: boolean(),
                 default: true

--- a/lib/membrane_webrtc/source.ex
+++ b/lib/membrane_webrtc/source.ex
@@ -114,7 +114,7 @@ defmodule Membrane.WebRTC.Source do
               ],
               ice_ip_filter: [
                 spec: (:inet.ip_address() -> boolean()) | nil,
-                default: fn _ -> true end
+                default: &__MODULE__.default_ice_ip_filter/1
               ],
               depayload_rtp: [
                 spec: boolean(),
@@ -271,4 +271,6 @@ defmodule Membrane.WebRTC.Source do
       clock_rate: ExWebRTCUtils.codec_clock_rate(:h264)
     })
   end
+
+  def default_ice_ip_filter(_), do: true
 end

--- a/lib/membrane_webrtc/source.ex
+++ b/lib/membrane_webrtc/source.ex
@@ -272,5 +272,5 @@ defmodule Membrane.WebRTC.Source do
     })
   end
 
-  def default_ice_ip_filter(_), do: true
+  def default_ice_ip_filter(_ip), do: true
 end


### PR DESCRIPTION
As per the `ex_webrtc` docs for bare deployment, `ice_port_range` might need to be set:

```elixir
PeerConnection.start_link(ice_port_range: 50_000..60_000)
```

And as per the `ex_webrtc` docs for Fly.io deployment, `ice_ip_filter` might need to be set:

```elixir
ip_filter = Application.get_env(:your_app, :ice_ip_filter)

{:ok, pc} =
  PeerConnection.start_link(
    ice_ip_filter: ip_filter,
    ice_servers: [%{urls: "stun:stun.l.google.com:19302"}]
  )
```

This PR adds the `ice_port_range` and `ice_ip_filter` options to the source and sink elements/bins