### PR TITLE
Allow to receive raw RTP in Sink / Allow to negotiate AV1 codecs

### DIFF
--- a/lib/membrane_webrtc/ex_webrtc/sink.ex
+++ b/lib/membrane_webrtc/ex_webrtc/sink.ex
@@ -151,8 +151,14 @@ defmodule Membrane.WebRTC.ExWebRTCSink do
     {[], state}
   end
 
-  defp set_pc_sender_video_codec(state, pad, codec) when codec in [:vp8, :h264] do
-    mime_type = if codec == :vp8, do: "video/VP8", else: "video/H264"
+  defp set_pc_sender_video_codec(state, pad, codec) when codec in [:vp8, :h264, :av1] do
+    mime_type =
+      case codec do
+        :vp8 -> "video/VP8"
+        :h264 -> "video/H264"
+        :av1 -> "video/AV1"
+      end
+
     transceiver = get_transceiver(state, pad)
 
     if transceiver == nil do

--- a/lib/membrane_webrtc/ex_webrtc/sink.ex
+++ b/lib/membrane_webrtc/ex_webrtc/sink.ex
@@ -130,7 +130,8 @@ defmodule Membrane.WebRTC.ExWebRTCSink do
         :ok
 
       %{kind: :video, codec: nil} ->
-        supported_video_codecs = get_transceiver(state, pad)
+        transceiver = get_transceiver(state, pad)
+        supported_video_codecs = transceiver.codecs
 
         if length(supported_video_codecs) > 1 do
           raise """
@@ -152,13 +153,7 @@ defmodule Membrane.WebRTC.ExWebRTCSink do
   end
 
   defp set_pc_sender_video_codec(state, pad, codec) when codec in [:vp8, :h264, :av1] do
-    mime_type =
-      case codec do
-        :vp8 -> "video/VP8"
-        :h264 -> "video/H264"
-        :av1 -> "video/AV1"
-      end
-
+    mime_type = mime_type_from_codec(codec)
     transceiver = get_transceiver(state, pad)
 
     if transceiver == nil do
@@ -377,4 +372,8 @@ defmodule Membrane.WebRTC.ExWebRTCSink do
     seq_num = rem(params.seq_num + 1, @max_rtp_seq_num + 1)
     put_in(state.input_tracks[pad], {id, %{params | seq_num: seq_num}})
   end
+
+  defp mime_type_from_codec(:h264), do: "video/H264"
+  defp mime_type_from_codec(:vp8), do: "video/VP8"
+  defp mime_type_from_codec(:av1), do: "video/AV1"
 end

--- a/lib/membrane_webrtc/ex_webrtc/utils.ex
+++ b/lib/membrane_webrtc/ex_webrtc/utils.ex
@@ -79,7 +79,7 @@ defmodule Membrane.WebRTC.ExWebRTCUtils do
     end
   end
 
-  @spec get_video_codecs_from_sdp(ExWebRTC.SessionDescription.t()) :: [:h264 | :vp8]
+  @spec get_video_codecs_from_sdp(ExWebRTC.SessionDescription.t()) :: [:h264 | :vp8 | :av1]
   def get_video_codecs_from_sdp(%ExWebRTC.SessionDescription{sdp: sdp}) do
     ex_sdp = ExSDP.parse!(sdp)
 
@@ -91,6 +91,7 @@ defmodule Membrane.WebRTC.ExWebRTCUtils do
     |> Enum.flat_map(fn
       %ExSDP.Attribute.RTPMapping{encoding: "H264"} -> [:h264]
       %ExSDP.Attribute.RTPMapping{encoding: "VP8"} -> [:vp8]
+      %ExSDP.Attribute.RTPMapping{encoding: "AV1"} -> [:av1]
       _attribute -> []
     end)
     |> Enum.uniq()

--- a/lib/membrane_webrtc/ex_webrtc/utils.ex
+++ b/lib/membrane_webrtc/ex_webrtc/utils.ex
@@ -43,6 +43,22 @@ defmodule Membrane.WebRTC.ExWebRTCUtils do
     ]
   end
 
+  def codec_params(:av1) do
+    [
+      %RTPCodecParameters{
+        payload_type: 45,
+        mime_type: "video/AV1",
+        clock_rate: codec_clock_rate(:av1),
+        sdp_fmtp_line: %ExSDP.Attribute.FMTP{
+          pt: 45,
+          profile: 0,
+          level_idx: 5,
+          tier: 0
+        }
+      }
+    ]
+  end
+
   def codec_params(codecs) when is_list(codecs) do
     codecs |> Enum.flat_map(&codec_params/1)
   end
@@ -51,6 +67,7 @@ defmodule Membrane.WebRTC.ExWebRTCUtils do
   def codec_clock_rate(:opus), do: 48_000
   def codec_clock_rate(:vp8), do: 90_000
   def codec_clock_rate(:h264), do: 90_000
+  def codec_clock_rate(:av1), do: 90_000
 
   def codec_clock_rate(codecs) when is_list(codecs) do
     cond do

--- a/lib/membrane_webrtc/sink.ex
+++ b/lib/membrane_webrtc/sink.ex
@@ -248,5 +248,5 @@ defmodule Membrane.WebRTC.Sink do
 
   defp ensure_single_video_codec(codec) when is_atom(codec), do: codec
   defp ensure_single_video_codec([codec]), do: codec
-  defp ensure_single_video_codec(_), do: nil
+  defp ensure_single_video_codec(_codec), do: nil
 end

--- a/lib/membrane_webrtc/source.ex
+++ b/lib/membrane_webrtc/source.ex
@@ -64,7 +64,7 @@ defmodule Membrane.WebRTC.Source do
                 """
               ],
               allowed_video_codecs: [
-                spec: :vp8 | :h264 | [:vp8 | :h264],
+                spec: :vp8 | :h264 | :av1 | [:vp8 | :h264 | :av1],
                 default: :vp8,
                 description: """
                 Specifies, which video codecs can be accepted by the source during the SDP
@@ -260,6 +260,14 @@ defmodule Membrane.WebRTC.Source do
 
       state.negotiated_video_codecs == nil ->
         raise "Cannot select depayloader before end of SDP messages exchange"
+
+      true ->
+        raise """
+        Unsupported video codec for depayloading: #{inspect(state.negotiated_video_codecs)}
+
+        If you're receiving raw RTP or using a codec without a built-in depayloader (like AV1),
+        set `depayload_rtp: false` in the Source options.
+        """
     end
   end
 

--- a/test/membrane_webrtc/integration_test.exs
+++ b/test/membrane_webrtc/integration_test.exs
@@ -69,7 +69,7 @@ defmodule Membrane.WebRTC.IntegrationTest do
   defmodule Utils do
     import ExUnit.Assertions
 
-    def fixture_processing_timeout, do: 30_000
+    def fixture_processing_timeout(), do: 30_000
 
     def prepare_input(pipeline, opts) do
       demuxer_name = {:demuxer, make_ref()}


### PR DESCRIPTION
We want the ability to receive the raw RTP packets (AV1) in our pipelie, which will allow to bypass everything else, including the payloading.

This code solves the problem for us, so we decided to raise a PR.

Please let me know what I should improve. Thank you in advance, Olexandr.